### PR TITLE
Cleanup bld scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,12 +86,12 @@ build:
  
 # scripts to run before build
 before_build:
-  - ps: .\updateInstallerVersion.ps1
-  - ps: .\downloadDLL.ps1
+  - ps: build/updateInstallerVersion.ps1
+  - ps: build/downloadDLL.ps1
 
 # scripts to run after build
 after_build:
-  - ps: .\pushArtifacts.ps1
+  - ps: build/pushArtifacts.ps1
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -150,3 +150,5 @@ notifications:
       - crovers@ptc.com
       - szhao@ptc.com
       - bleskowsky@ptc.com
+      - atusek@ptc.com
+      - gfleming@ptc.com

--- a/build/downloadDLL.ps1
+++ b/build/downloadDLL.ps1
@@ -17,7 +17,7 @@ $accountName = "PTC-ALM"
 $projectSlug = "TortoiseSI"
 
 # determine root directory
-$root = Resolve-Path ..
+$root = Resolve-Path .
 $downloadLocation = "$root\bin\Release\bin\"
 
 # get project based on current build version

--- a/build/downloadDLL.ps1
+++ b/build/downloadDLL.ps1
@@ -17,7 +17,7 @@ $accountName = "PTC-ALM"
 $projectSlug = "TortoiseSI"
 
 # determine root directory
-$root = Resolve-Path .
+$root = Resolve-Path ..
 $downloadLocation = "$root\bin\Release\bin\"
 
 # get project based on current build version

--- a/build/pushArtifacts.ps1
+++ b/build/pushArtifacts.ps1
@@ -4,7 +4,7 @@ Set-ExecutionPolicy Bypass -Force
 # If building Win32 version, upload TortoiseSI32.dll
 if($Env:Platform -eq "Win32")
 {
-	$root = Resolve-Path .
+	$root = Resolve-Path ..
 	Push-AppveyorArtifact "$root\bin\Release\bin\TortoiseSI32.dll"
 	Push-AppveyorArtifact "$root\bin\Release\bin\TortoiseSIStub32.dll"
 	Write-host "Uploaded TortoiseSI32.dll and TortoiseSIStub32.dll"

--- a/build/pushArtifacts.ps1
+++ b/build/pushArtifacts.ps1
@@ -4,7 +4,7 @@ Set-ExecutionPolicy Bypass -Force
 # If building Win32 version, upload TortoiseSI32.dll
 if($Env:Platform -eq "Win32")
 {
-	$root = Resolve-Path ..
+	$root = Resolve-Path .
 	Push-AppveyorArtifact "$root\bin\Release\bin\TortoiseSI32.dll"
 	Push-AppveyorArtifact "$root\bin\Release\bin\TortoiseSIStub32.dll"
 	Write-host "Uploaded TortoiseSI32.dll and TortoiseSIStub32.dll"

--- a/build/updateInstallerVersion.ps1
+++ b/build/updateInstallerVersion.ps1
@@ -3,7 +3,7 @@ Set-ExecutionPolicy Bypass -Force
 
 $version = $Env:APPVEYOR_BUILD_VERSION
 
-$root = Resolve-Path ..
+$root = Resolve-Path .
 $header = "$root\src\version.h"
 $versionNumberInclude = "$root\src\TortoiseSISetup\VersionNumberInclude.wxi"
 

--- a/build/updateInstallerVersion.ps1
+++ b/build/updateInstallerVersion.ps1
@@ -3,7 +3,7 @@ Set-ExecutionPolicy Bypass -Force
 
 $version = $Env:APPVEYOR_BUILD_VERSION
 
-$root = Resolve-Path .
+$root = Resolve-Path ..
 $header = "$root/src/version.h"
 $versionNumberInclude = "$root/src/TortoiseSISetup/VersionNumberInclude.wxi"
 

--- a/build/updateInstallerVersion.ps1
+++ b/build/updateInstallerVersion.ps1
@@ -4,8 +4,8 @@ Set-ExecutionPolicy Bypass -Force
 $version = $Env:APPVEYOR_BUILD_VERSION
 
 $root = Resolve-Path ..
-$header = "$root/src/version.h"
-$versionNumberInclude = "$root/src/TortoiseSISetup/VersionNumberInclude.wxi"
+$header = "$root\src\version.h"
+$versionNumberInclude = "$root\src\TortoiseSISetup\VersionNumberInclude.wxi"
 
 $split = $version.replace(' ', '').split('.')
 
@@ -16,6 +16,8 @@ $split = $version.replace(' ', '').split('.')
 # split[3] -> Build Version
 
 # Modify version.h
+Write-host "Attempt to modify $header to use version $version"
+
 (Copy-Item $header "$($header).bak")
 
 (Get-Content $header) |
@@ -29,9 +31,11 @@ Foreach-Object {$_ -replace '^#define TGIT_VERMICRO.+', "#define TGIT_VERMICRO 	
 Foreach-Object {$_ -replace '^#define TGIT_VERBUILD.+', "#define TGIT_VERBUILD 		$($split[3])"} |
 Out-file $header
 
-Write-host "Modified $header to use version $version"
+
 
 # Modify VersionNumberInclude.wxi
+Write-host "Attempt to modify $versionNumberInclude to use version $version"
+
 (Copy-Item $versionNumberInclude "$($versionNumberInclude).bak")
 
 (Get-Content $versionNumberInclude) |
@@ -41,4 +45,3 @@ Foreach-Object {$_ -replace "MicroVersion=""\d*""", "MicroVersion=""$($split[2])
 Foreach-Object {$_ -replace "BuildVersion=""\d*""", "BuildVersion=""$($split[3])"""} |
 Out-file $versionNumberInclude -Encoding "UTF8"
 
-Write-host "Modified $versionNumberInclude to use version $version"


### PR DESCRIPTION
Move the powershell scripts into their own separate build folder, rather than keeping it in the root directory.
