### PR TITLE
Issue16 - Files in a controlled directory have status icons. Fix Sequence Not Ordered exceptions.

### DIFF
--- a/src/TortoiseShell/IconOverlay.cpp
+++ b/src/TortoiseShell/IconOverlay.cpp
@@ -199,6 +199,107 @@ FileStatusFlags	CShellExt::getPathStatus(std::wstring path)
 		// slots some of our overlays aren't loaded. But we assume that
 		// at least the 'normal' and 'modified' overlay are available.
 
+
+	// error case
+	 if (fileStatusFlags == 0) {
+		 return S_FALSE;
+	 }
+	// locked
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::Locked)) {
+		 if (g_lockedovlloaded && m_State == FileStateLockedOverlay) {
+			 return S_OK;
+		 }
+		 else if (!g_lockedovlloaded && m_State == FileStateVersioned) {
+			 return S_OK;
+		 }
+		 else {
+			 return S_FALSE;
+		 }
+	 }
+	// incoming
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::Incoming)) {
+		 if (g_conflictedovlloaded && m_State == FileStateConflict) {
+			 return S_OK;
+		 }
+		 else if (!g_conflictedovlloaded && m_State == FileStateModified) {
+			 // the 'conflicted' overlay isn't available (due to lack of enough
+			 // overlay slots). So just show the 'modified' overlay instead.
+			 return S_OK;
+		 }
+		 else {
+			 return S_FALSE;
+		 }
+	 }
+	// formermember
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::FormerMember)) {
+		 if (g_deletedovlloaded && m_State == FileStateDeleted) {
+			 return S_OK;
+		 }
+		 else if (!g_deletedovlloaded && m_State == FileStateModified) {
+			 // the 'deleted' overlay isn't available (due to lack of enough
+			 // overlay slots). So just show the 'modified' overlay instead.
+			 return S_OK;
+		 }
+		 else {
+			 return S_FALSE;
+		 }
+	 }
+	// merge needed
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::MergeNeeded)) {
+		 if (m_State == FileStateConflict) {
+			 return S_OK;
+		 }
+		 else {
+			 return S_FALSE;
+		 }
+	 }
+	// renamed, moved, modified
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::Modified)
+		 || hasFileStatus(fileStatusFlags, FileStatus::Moved)
+		 || hasFileStatus(fileStatusFlags, FileStatus::Renamed)) {
+
+		 if (m_State == FileStateModified) {
+			 return S_OK;
+		 }
+		 else {
+			 return S_FALSE;
+		 }
+	 }
+	// drop
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::Drop)) {
+		 if (m_State == FileStateDeleted) {
+			 return S_OK;
+		 }
+		 else {
+			 return S_FALSE;
+		 }
+	 }
+	// add
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::Add)) {
+		 if (g_addedovlloaded && m_State == FileStateAddedOverlay){
+			 return S_OK;
+		 }
+		 else	if (!g_addedovlloaded && m_State == FileStateModified) {
+			 // the 'added' overlay isn't available (due to lack of enough
+			 // overlay slots). So just show the 'modified' overlay instead.
+			 return S_OK;
+		 }
+		 else {
+			 return S_FALSE;
+		 }
+	 }
+	// member
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::Member)) {
+		 if (m_State == FileStateVersioned) {
+			 return S_OK;
+		 }
+		 else {
+			 return S_FALSE;
+		 }
+	 }
+	 return S_FALSE;
+
+	 /*
 	if (fileStatusFlags == 0) {
 		 return S_FALSE;	
 	} else if (hasFileStatus(fileStatusFlags, FileStatus::FormerMember)) {
@@ -255,5 +356,19 @@ FileStatusFlags	CShellExt::getPathStatus(std::wstring path)
 			 return S_FALSE;
 		 }
 	 }
-	 return S_FALSE;
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::MergeNeeded)) {
+		 if (m_State == FileStateConflict) {
+			 return S_OK;
+		 } else {
+			 return S_FALSE;
+		 }
+	 }
+	 else if (hasFileStatus(fileStatusFlags, FileStatus::Drop)) {
+		 if (m_State == FileStateDeleted) {
+			 return S_OK;
+		 } else {
+			 return S_FALSE;
+		 }
+	 }
+	 return S_FALSE;*/
  }

--- a/src/TortoiseShell/RootFolderCache.cpp
+++ b/src/TortoiseShell/RootFolderCache.cpp
@@ -92,8 +92,6 @@ void RootFolderCache::updateFoldersList()
 {
 	std::vector<std::wstring> rootFolders = IntegrityActions::getControlledPaths(integritySession);
 
-	std::sort(rootFolders.begin(), rootFolders.end(), std::less<std::wstring>());
-
 	// to lower case everything
 	for (std::wstring& rootPath : rootFolders) {
 		if (rootPath.at(rootPath.size() - 1) != '\\') {
@@ -102,6 +100,8 @@ void RootFolderCache::updateFoldersList()
 
 		std::transform(rootPath.begin(), rootPath.end(), rootPath.begin(), ::tolower);
 	}
+
+	std::sort(rootFolders.begin(), rootFolders.end(), std::less<std::wstring>());
 
 	// lock cach and copy back
 	std::vector<std::wstring> oldRootFolders;

--- a/src/TortoiseShell/RootFolderCache.cpp
+++ b/src/TortoiseShell/RootFolderCache.cpp
@@ -92,6 +92,8 @@ void RootFolderCache::updateFoldersList()
 {
 	std::vector<std::wstring> rootFolders = IntegrityActions::getControlledPaths(integritySession);
 
+	std::sort(rootFolders.begin(), rootFolders.end(), std::less<std::wstring>());
+
 	// to lower case everything
 	for (std::wstring& rootPath : rootFolders) {
 		if (rootPath.at(rootPath.size() - 1) != '\\') {


### PR DESCRIPTION
Fix for issue #16. This adds functionality for setting appropriate overlay hierarchy in the case of overlays that can't be loaded (see notes in issue #16). Also a fix in here for sequence not ordered exceptions.
