### PR TITLE
Make NeedsMerge case show Tortoise Modified icon instead of Conflict

### DIFF
--- a/src/TortoiseShell/IconOverlay.cpp
+++ b/src/TortoiseShell/IconOverlay.cpp
@@ -243,17 +243,10 @@ FileStatusFlags	CShellExt::getPathStatus(std::wstring path)
 			 return S_FALSE;
 		 }
 	 }
-	 else if (hasFileStatus(fileStatusFlags, FileStatus::MergeNeeded)) {
-		 if (m_State == FileStateModified) {
-			 return S_OK;
-		 }
-		 else {
-			 return S_FALSE;
-		 }
-	 }
 	 else if (hasFileStatus(fileStatusFlags, FileStatus::Modified)
 		 || hasFileStatus(fileStatusFlags, FileStatus::Moved)
-		 || hasFileStatus(fileStatusFlags, FileStatus::Renamed)) {
+		 || hasFileStatus(fileStatusFlags, FileStatus::Renamed)
+		 || hasFileStatus(fileStatusFlags, FileStatus::MergeNeeded)) {
 
 		 if (m_State == FileStateModified) {
 			 return S_OK;

--- a/src/TortoiseShell/IconOverlay.cpp
+++ b/src/TortoiseShell/IconOverlay.cpp
@@ -244,10 +244,7 @@ FileStatusFlags	CShellExt::getPathStatus(std::wstring path)
 		 }
 	 }
 	 else if (hasFileStatus(fileStatusFlags, FileStatus::MergeNeeded)) {
-		 if (g_conflictedovlloaded && m_State == FileStateConflict) {
-			 return S_OK;
-		 }
-		 else if (!g_conflictedovlloaded && m_State == FileStateModified) {
+		 if (m_State == FileStateModified) {
 			 return S_OK;
 		 }
 		 else {


### PR DESCRIPTION
Fix for issue #16 post-sprint review comment that modified locally should take precedence over incoming changes.

Changed so that if file status is MergeNeeded, load FileStateModified overlay (red exclamation mark)
