### PR TITLE
Fix for issue #10 - Explorer crashing on refresh

### DIFF
--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -209,12 +209,6 @@ namespace IntegrityActions {
 		if (status != std::future_status::ready) {
 			EventLog::writeWarning(L"get status timeout for " + file);
 
-			// need to call get so that the unique_ptr will exisit somewhere and go out of 
-			// scope and delete the command runner / response
-			std::async(std::launch::async, [&]{ 
-					std::unique_ptr<IntegrityResponse> response = responseFuture.get(); 
-				});
-
 			return (FileStatusFlags)FileStatus::TimeoutError;
 		}
 


### PR DESCRIPTION
Fix for issue #10:

Removed code meant to clean up command response in the event of a timeout. Code was causing explorer to crash.
