### PR TITLE
Issue83

### DIFF
--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -131,6 +131,29 @@ namespace IntegrityActions {
 		executeUserCommand(session, initializeWFExecute(command), onDone);
 	}
 
+	void moveFiles(const IntegritySession& session, std::vector<std::wstring> paths, std::function<void()> onDone) 
+	{
+		IntegrityCommand command(L"si", L"move");
+		command.addOption(L"g");
+		
+		for (std::wstring path : paths) {
+			command.addSelection(path);
+		}
+
+		executeUserCommand(session, initializeWFExecute(command), onDone);
+	}
+
+	void renameFiles(const IntegritySession& session, std::vector<std::wstring> paths, std::function<void()> onDone) 
+	{
+		IntegrityCommand command(L"si", L"rename");
+		command.addOption(L"g");
+
+		for (std::wstring path : paths) {
+			command.addSelection(path);
+		}
+
+		executeUserCommand(session, initializeWFExecute(command), onDone);
+	}
 
 	void resyncFiles(const IntegritySession& session, std::vector<std::wstring> paths, std::function<void()> onDone)
 	{

--- a/src/Resources/TortoiseShellENG.rc
+++ b/src/Resources/TortoiseShellENG.rc
@@ -258,6 +258,10 @@ BEGIN
     IDS_LOCK_DESC           "Lock project members"
     IDS_REVERT              "Revert"
     IDS_REVERT_DESC         "Overwrite a sandbox file with a fresh copy of the working file, discarding changes"
+    IDS_RENAME              "Rename"
+    IDS_RENAME_DESC         "Rename an existing project member"
+    IDS_MOVE                "Move"
+    IDS_MOVE_DESC           "Move one or more project members between projects, or between directories in a single project"
 END
 
 #endif    // English (United States) resources

--- a/src/Resources/TortoiseShellENG.rc
+++ b/src/Resources/TortoiseShellENG.rc
@@ -242,25 +242,25 @@ BEGIN
                             "Show member information view for selected member"
     IDS_VIEW_HISTORY        "Member History"
     IDS_VIEW_HISTORY_DESC   "Show member history view for selected member"
-    IDS_ADD_NONMEMBER       "Add"
+    IDS_ADD_NONMEMBER       "Add..."
     IDS_ADD_NONMEMBER_DESC  "Add non-members to sandbox"
-    IDS_CHECKOUT            "Check Out"
+    IDS_CHECKOUT            "Check Out..."
     IDS_CHECKOUT_DESC       "Check out members into working files in a sandbox"
-    IDS_CHECKIN             "Check In"
+    IDS_CHECKIN             "Check In..."
     IDS_CHECKIN_DESC        "Check in members of a sandbox"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_DROP                "Drop"
+    IDS_DROP                "Drop..."
     IDS_DROP_DESC           "Drop a member from a project"
-    IDS_LOCK                "Lock"
+    IDS_LOCK                "Lock..."
     IDS_LOCK_DESC           "Lock project members"
-    IDS_REVERT              "Revert"
+    IDS_REVERT              "Revert..."
     IDS_REVERT_DESC         "Overwrite a sandbox file with a fresh copy of the working file, discarding changes"
-    IDS_RENAME              "Rename"
+    IDS_RENAME              "Rename..."
     IDS_RENAME_DESC         "Rename an existing project member"
-    IDS_MOVE                "Move"
+    IDS_MOVE                "Move..."
     IDS_MOVE_DESC           "Move one or more project members between projects, or between directories in a single project"
 END
 

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -573,7 +573,7 @@ std::vector<MenuInfo> menuInfo =
 				hasFileStatus(selectedItemsStatus, FileStatus::Member);
 		}
 	},
-	{ MenuItem::Move, IDI_REBASE, IDS_MOVE, IDS_MOVE_DESC,
+	{ MenuItem::Move, IDI_RELOCATE, IDS_MOVE, IDS_MOVE_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND parentWindow)
 		{
 			std::wstring file;

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -573,6 +573,54 @@ std::vector<MenuInfo> menuInfo =
 				hasFileStatus(selectedItemsStatus, FileStatus::Member);
 		}
 	},
+	{ MenuItem::Move, IDI_REBASE, IDS_MOVE, IDS_MOVE_DESC,
+	[](const std::vector<std::wstring>& selectedItems, HWND parentWindow)
+		{
+			std::wstring file;
+			std::wstring folder;
+
+			if (selectedItems.empty()) {
+				EventLog::writeDebug(L"selected items list empty for move operation");
+				return;
+			}
+
+			file = selectedItems.front();
+
+			folder = file.substr(0, file.find_last_of('\\'));
+
+			IntegrityActions::moveFiles(getIntegritySession(), selectedItems,
+				[folder] {refreshFolder(folder); });
+		},
+			[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
+		{
+			return hasFileStatus(selectedItemsStatus, FileStatus::File) &&
+				hasFileStatus(selectedItemsStatus, FileStatus::Member);
+		}
+	},
+	{ MenuItem::Rename, IDI_RENAME, IDS_RENAME, IDS_RENAME_DESC,
+	[](const std::vector<std::wstring>& selectedItems, HWND parentWindow)
+		{
+			std::wstring file;
+			std::wstring folder;
+
+			if (selectedItems.empty()) {
+				EventLog::writeDebug(L"selected items list empty for rename operation");
+				return;
+			}
+
+			file = selectedItems.front();
+
+			folder = file.substr(0, file.find_last_of('\\'));
+
+			IntegrityActions::renameFiles(getIntegritySession(), selectedItems,
+				[folder] {refreshFolder(folder); });
+		},
+			[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
+		{
+			return hasFileStatus(selectedItemsStatus, FileStatus::File) &&
+				hasFileStatus(selectedItemsStatus, FileStatus::Member);
+		}
+	},
 	menuSeperator,
 	{ MenuItem::IgnoreSubMenu, 0, IDS_IGNORE_SUBMENU, IDS_IGNORE_SUBMENU_DESC,
 		nullptr, // CShellExt::InsertIgnoreSubmenus define the actions associated with menu

--- a/src/TortoiseShell/MenuInfo.h
+++ b/src/TortoiseShell/MenuInfo.h
@@ -44,7 +44,9 @@ enum MenuItem {
 	Drop,
 	Lock,
 	CheckIn,
-	Revert
+	Revert,
+	Move,
+	Rename
 };
 
 struct MenuInfo

--- a/src/TortoiseShell/resource.h
+++ b/src/TortoiseShell/resource.h
@@ -127,9 +127,13 @@
 #define IDS_STATUSIGNORED               197
 #define IDS_REVERT_DESC                 197
 #define IDS_DROPCOPYMENU                198
+#define IDS_RENAME                      198
 #define IDS_PROPWAITCANCEL              199
+#define IDS_RENAME_DESC                 199
 #define IDS_SETPROPTITLE                200
+#define IDS_MOVE                        200
 #define IDS_MENUDESCBISECTBAD           201
+#define IDS_MOVE_DESC                   201
 #define IDS_MENUDESCBISECTRESET         202
 #define IDS_MENUBLAME                   203
 #define IDS_STATUSEXTERNAL              204


### PR DESCRIPTION
Code changes for issue #83. Expose Move and Rename gestures in TortoiseSI. Append "..." to file-based ops resource strings which open dialog. This will avoid problem where "Rename" will make Windows rename call and not go into CShellExt::InvokeCommand().
