### PR TITLE
Provide working file changes Integrity Action

### DIFF
--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -407,7 +407,7 @@ namespace IntegrityActions {
 		command.addSelection(path);
 
 		std::unique_ptr<IntegrityResponse> response = session.execute(command);
-
+	
 		if (response->getException() != NULL) {
 			logAnyExceptions(*response);
 			displayException(*response);
@@ -415,6 +415,7 @@ namespace IntegrityActions {
 		}
 		
 		for (mksWorkItem item : *response) {
+
 			std::wstring id = getId(item);
 			int status = getIntegerFieldValue(item, L"status", NO_STATUS);
 

--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -408,6 +408,12 @@ namespace IntegrityActions {
 
 		std::unique_ptr<IntegrityResponse> response = session.execute(command);
 
+		if (response->getException() != NULL) {
+			logAnyExceptions(*response);
+			displayException(*response);
+			return changes;
+		}
+		
 		for (mksWorkItem item : *response) {
 			std::wstring id = getId(item);
 			int status = getIntegerFieldValue(item, L"status", NO_STATUS);

--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -220,8 +220,6 @@ namespace IntegrityActions {
 		executeUserCommand(session, command, onDone);
 	}
 
-	const FileStatusFlags NO_STATUS = 0;
-
 	// get status flags for a set of files...
 	FileStatusFlags fileInfo(const IntegritySession& session, const std::wstring& file) 
 	{
@@ -387,7 +385,7 @@ namespace IntegrityActions {
 
 			// Create change package object
 			std::shared_ptr<IntegrityActions::ChangePackage> cp = std::shared_ptr<IntegrityActions::ChangePackage>(IntegrityActions::ChangePackage::ChangePackageBuilder()
-				.setID(id)
+				.setId(id)
 				.setSummary(summary)
 				.setDescription(description)
 				.setType(cptype)
@@ -398,6 +396,32 @@ namespace IntegrityActions {
 		}
 
 		return cps;
+	}
+
+	/**
+	 * Retrieve list of working file changes for path 
+	 */
+	std::vector<std::shared_ptr<IntegrityActions::WorkingFileChange>> getWorkingFileChanges(const IntegritySession& session, std::wstring path) {
+		std::vector<std::shared_ptr<IntegrityActions::WorkingFileChange>> changes;
+		IntegrityCommand command(L"wf", L"changes");
+		command.addSelection(path);
+
+		std::unique_ptr<IntegrityResponse> response = session.execute(command);
+
+		for (mksWorkItem item : *response) {
+			std::wstring id = getId(item);
+			int status = getIntegerFieldValue(item, L"status", NO_STATUS);
+
+			// Create change package object
+			std::shared_ptr<IntegrityActions::WorkingFileChange> change = std::shared_ptr<IntegrityActions::WorkingFileChange>(IntegrityActions::WorkingFileChange::WorkingFileChangeBuilder()
+				.setId(id)
+				.setStatus(status)
+				.build());
+
+			changes.push_back(change);
+		}
+
+		return changes;
 	}
 
 	/**

--- a/src/Integrity/IntegrityActions.h
+++ b/src/Integrity/IntegrityActions.h
@@ -27,6 +27,45 @@
 
 namespace IntegrityActions {
 
+	const FileStatusFlags NO_STATUS = 0;
+
+	class WorkingFileChange {
+	public:
+		class WorkingFileChangeBuilder;
+
+	private:
+		std::wstring m_id;
+		int m_status;
+
+		WorkingFileChange(std::wstring id, int status) : m_id(id), m_status(status) {};
+
+	public:
+		std::wstring getId() { return m_id; }
+		int getStatus() { return m_status; }
+	};
+
+	class WorkingFileChange::WorkingFileChangeBuilder {
+	private:
+		std::wstring m_id;
+		int m_status = NO_STATUS;
+
+	public:
+		WorkingFileChangeBuilder& setId(std::wstring id) { m_id = id; return *this; }
+		WorkingFileChangeBuilder& setStatus(int status) { m_status = status; return *this; }
+		
+		WorkingFileChange* build() {
+			if (m_id.empty()) {
+				throw new std::exception("Attempt to construct WorkingFileChange that does not have valid id");
+			}
+			if (m_status == NO_STATUS) {
+				throw new std::exception("Attempt to construct WorkingFileChange with invalid status");
+			}
+			return new WorkingFileChange(m_id, m_status);
+		}
+
+	};
+
+
 	class ChangePackage {
 	public:
 		// Use this class to construct a valid ChangePackage
@@ -47,7 +86,7 @@ namespace IntegrityActions {
 	public:
 		// ChangePackage specific functionality
 		std::wstring getId() { return m_id; }
-		std::wstring getSumamry() { return m_summary; }
+		std::wstring getSummary() { return m_summary; }
 		std::wstring getDescription() { return m_description; }
 		std::wstring getType() { return m_cptype; }
 		std::wstring getIssueId() { return m_issueId; }
@@ -63,7 +102,7 @@ namespace IntegrityActions {
 		std::wstring m_issueId;
 
 	public:
-		ChangePackageBuilder& setID(const std::wstring id) { m_id = id; return *this; }
+		ChangePackageBuilder& setId(const std::wstring id) { m_id = id; return *this; }
 		ChangePackageBuilder& setSummary(const std::wstring summary) { m_summary = summary; return *this; }
 		ChangePackageBuilder& setDescription(const std::wstring description) { m_description = description; return *this; }
 		ChangePackageBuilder& setType(const std::wstring cptype) { m_cptype = cptype; return *this; }
@@ -99,6 +138,9 @@ namespace IntegrityActions {
 
 	// list of change packages
 	std::vector<std::shared_ptr<IntegrityActions::ChangePackage>> getChangePackageList(const IntegritySession& session);
+
+	// list of working file changes
+	std::vector<std::shared_ptr<IntegrityActions::WorkingFileChange>> getWorkingFileChanges(const IntegritySession& session, std::wstring path);
 
 	bool connect(const IntegritySession& session);
 

--- a/src/Integrity/IntegrityActions.h
+++ b/src/Integrity/IntegrityActions.h
@@ -40,8 +40,8 @@ namespace IntegrityActions {
 		WorkingFileChange(std::wstring id, int status) : m_id(id), m_status(status) {};
 
 	public:
-		std::wstring getId() { return m_id; }
-		int getStatus() { return m_status; }
+		std::wstring getId() const { return m_id; }
+		int getStatus() const { return m_status; }
 	};
 
 	class WorkingFileChange::WorkingFileChangeBuilder {
@@ -50,8 +50,8 @@ namespace IntegrityActions {
 		int m_status = NO_STATUS;
 
 	public:
-		WorkingFileChangeBuilder& setId(std::wstring id) { m_id = id; return *this; }
-		WorkingFileChangeBuilder& setStatus(int status) { m_status = status; return *this; }
+		WorkingFileChangeBuilder& setId(const std::wstring id) { m_id = id; return *this; }
+		WorkingFileChangeBuilder& setStatus(const int status) { m_status = status; return *this; }
 		
 		WorkingFileChange* build() {
 			if (m_id.empty()) {

--- a/src/Integrity/IntegritySession.cpp
+++ b/src/Integrity/IntegritySession.cpp
@@ -28,7 +28,7 @@ IntegritySession::IntegritySession()
 
 	initAPI();
 
-	mksCreateLocalIntegrationPoint(&ip, TRUE);
+	mksCreateLocalAPIConnector(&ip, 4, 15, TRUE);
 	if (ip != NULL) {
 		mksGetCommonSession(&session, ip);
 	}
@@ -41,7 +41,7 @@ IntegritySession::IntegritySession(std::string hostname, int port)
 
 	initAPI();
 
-	mksCreateIntegrationPoint(&ip, hostname.c_str(), port, FALSE);
+	mksCreateAPIConnector(&ip, hostname.c_str(), port, FALSE, 4, 15);
 	if (ip != NULL) {
 		mksGetCommonSession(&session, ip);
 	}

--- a/src/TortoiseProc/Commands/SICommitDlg.cpp
+++ b/src/TortoiseProc/Commands/SICommitDlg.cpp
@@ -141,7 +141,7 @@ BOOL CSICommitDlg::OnInitDialog()
 	// Add active change package ids and summary to combobox.
 	// Store ChangePackage information as item data for later reference
 	for (std::shared_ptr<IntegrityActions::ChangePackage> cp : IntegrityActions::getChangePackageList(*(theApp.m_integritySession))) {
-		std::wstring cpText = cp->getId() + L" " + cp->getSumamry();
+		std::wstring cpText = cp->getId() + L" " + cp->getSummary();
 		int idx = m_ctrlChangePackageComboBox.AddString(cpText.c_str());
 		m_ctrlChangePackageComboBox.SetItemDataPtr(idx, &cp);
 	}
@@ -237,7 +237,7 @@ void CSICommitDlg::OnBnClickedCreateCpButton()
 
 		// Update cp combobox to include newly created cp
 		for (std::shared_ptr<IntegrityActions::ChangePackage> cp : IntegrityActions::getChangePackageList(*(theApp.m_integritySession))) {
-			std::wstring cpText = cp->getId() + L" " + cp->getSumamry();
+			std::wstring cpText = cp->getId() + L" " + cp->getSummary();
 			int idx = m_ctrlChangePackageComboBox.AddString(cpText.c_str());
 			m_ctrlChangePackageComboBox.SetItemDataPtr(idx, &cp);
 		}


### PR DESCRIPTION
Initial code changes for #96.
- Expose command to get working file changes
- Minor code fixes
- Specify API 4.15 when creating the integration point (deprecated calls defaulted to 4.9, causing problems for wf changes)
