### PR TITLE
Fix for session worker threads not terminating

### DIFF
--- a/src/Integrity/IntegritySession.cpp
+++ b/src/Integrity/IntegritySession.cpp
@@ -56,8 +56,9 @@ void IntegritySession::initAPI()
 IntegritySession::~IntegritySession()
 {
 	if (ip != NULL) {
-		mksReleaseIntegrationPoint(ip);
-		mksAPITerminate();
+		//mksReleaseIntegrationPoint(ip);
+		mksReleaseSession(session);
+		//mksAPITerminate();
 
 		ip = NULL;
 		session = NULL;

--- a/src/TortoiseProc/TortoiseSIProc.cpp
+++ b/src/TortoiseProc/TortoiseSIProc.cpp
@@ -123,12 +123,12 @@ BOOL CTortoiseSIProcApp::InitInstance()
 	int port = getIntegrationPort();
 
 	if (port > 0 && port <= std::numeric_limits<unsigned short>::max()) {
-		//EventLog::writeInformation(L"TortoiseSIProcApp connecting to Integrity client via localhost:" + std::to_wstring(port));
+		EventLog::writeInformation(L"TortoiseSIProcApp connecting to Integrity client via localhost:" + std::to_wstring(port));
 		m_integritySession = std::unique_ptr<IntegritySession>(new IntegritySession("localhost", port));
 
 	}
 	else {
-		//EventLog::writeInformation(L"TortoiseSIProcApp connecting to Integrity client via localintegration point");
+		EventLog::writeInformation(L"TortoiseSIProcApp connecting to Integrity client via localintegration point");
 		m_integritySession = std::unique_ptr<IntegritySession>(new IntegritySession());
 	}
 

--- a/src/TortoiseProc/TortoiseSIProc.cpp
+++ b/src/TortoiseProc/TortoiseSIProc.cpp
@@ -134,10 +134,10 @@ BOOL CTortoiseSIProcApp::InitInstance()
 
 	m_serverConnectionsCache = std::unique_ptr<ServerConnections>(new ServerConnections(*m_integritySession));
 
-	//if (!m_serverConnectionsCache->isOnline()) {
-	//	EventLog::writeInformation(L"TortoiseSIProcApp::InitInstance() bailing out, unable to connected to server");
-	//	return FALSE;
-	//}
+	if (!m_serverConnectionsCache->isOnline()) {
+		EventLog::writeInformation(L"TortoiseSIProcApp::InitInstance() bailing out, unable to connected to server");
+		return FALSE;
+	}
 
 	if (!ProcessCommandLine()) {
 		return FALSE;


### PR DESCRIPTION
Some session worker threads were not terminating causing TortoiseSIProc process not to terminate when application exited.
