### PR TITLE
32Bit installation

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,15 +26,17 @@
         <p>TortoiseSI is in an <strong>Alpha</strong> Release phase. Please see the <a href="docs/alpha/TortoiseSIUserGuide_en.html" target="_blank">user documentation</a> for a description of the existing functionality.</p>
 		<p>Known issues and planned features that are not yet implemented can be found in the GitHub <a href="https://github.com/PTC-ALM/TortoiseSI/issues" target="_blank">issue list</a>.</p>
 		<p>TortoiseSI is developed as an Open Source project under the <a href="https://www.gnu.org/licenses/gpl-2.0.txt" target="_blank">GNU General Public License (GPL-2.0)</a>.</p>
-		
+
 		<br/><h1>Downloads</h1>
-		<p>The <strong>Alpha</strong> release is build <a href="https://ci.appveyor.com/api/buildjobs/t5y022s0ngvdto3h/artifacts/TortoiseSI-1.0.156.0-x64.msi">1.0.156.0</a>.</p>
+		<p>The <strong>Alpha</strong> release is build: </p>
+		<p><a href="https://ci.appveyor.com/api/buildjobs/86hkc9pi12rj7634/artifacts/TortoiseSI-1.0.156.0-x86.msi">Click Here</a> for 32-bit Installer</p>
+		<p><a href="https://ci.appveyor.com/api/buildjobs/t5y022s0ngvdto3h/artifacts/TortoiseSI-1.0.156.0-x64.msi">Click Here</a> for 64-Bit Installer</p>
 		<p>This build is not supported by PTC Technical Support. During this phase of release, contact <a href="mailto:alm-oss@ptc.com">alm-oss@ptc.com</a> for questions or to join the project team.</p>
-		
+
         <br/><h1>Need help getting started?</h1>
 		<p>Read the <a href="docs/alpha/TortoiseSIUserGuide_en.html" target="_blank">TortoiseSI for PTC Integrity User Guide - Alpha Release</a> for information on how to install and use TortoiseSI.</p>
 		<p>Please see the <a href="http://github.com/PTC-ALM/TortoiseSI/wiki" target="_blank">wiki</a> for information on how to contribute to this project.</p>
-		
+
 		<br/><h1>Contact</h1>
         <p><a href="mailto:alm-oss@ptc.com?subject=TortoiseSI">alm-oss@ptc.com</a></p>
       </section>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 		<p>TortoiseSI is developed as an Open Source project under the <a href="https://www.gnu.org/licenses/gpl-2.0.txt" target="_blank">GNU General Public License (GPL-2.0)</a>.</p>
 
 		<br/><h1>Downloads</h1>
-		<p>The <strong>Alpha</strong> release is build: </p>
+		<p>The <strong>Alpha</strong> release is build 1.0.156.0: </p>
 		<p><a href="https://ci.appveyor.com/api/buildjobs/86hkc9pi12rj7634/artifacts/TortoiseSI-1.0.156.0-x86.msi">Click Here</a> for 32-bit Installer</p>
 		<p><a href="https://ci.appveyor.com/api/buildjobs/t5y022s0ngvdto3h/artifacts/TortoiseSI-1.0.156.0-x64.msi">Click Here</a> for 64-Bit Installer</p>
 		<p>This build is not supported by PTC Technical Support. During this phase of release, contact <a href="mailto:alm-oss@ptc.com">alm-oss@ptc.com</a> for questions or to join the project team.</p>


### PR DESCRIPTION
#133 Added the link for 32 bit installer for the 156 build to https://ptc-alm.github.io/TortoiseSI/
