### PR TITLE
Changes to Merge Conflicts actions to make it more selection specific

### DIFF
--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -63,7 +63,9 @@ namespace IntegrityActions {
 	void mergeConflicts(const IntegritySession& session, std::wstring path)
 	{
 		IntegrityCommand command(L"si", L"merge");
+		command.addOption(L"cwd", path);
 		command.addOption(L"g");
+		command.addSelection(path);
 
 		executeUserCommand(session, command, nullptr);
 	}
@@ -249,7 +251,7 @@ namespace IntegrityActions {
 	void setExcludeFileFilter(const IntegritySession& session, std::vector<std::wstring> patterns, std::function<void()> onDone)
 	{
 		IntegrityCommand command(L"si", L"setprefs");
-		command.addOption(L"command",L"viewnonmembers");
+		command.addOption(L"command", L"viewnonmembers");
 
 		std::wstring patternString;
 		if (!patterns.empty()) {
@@ -266,6 +268,7 @@ namespace IntegrityActions {
 
 		executeUserCommand(session, command, onDone);
 	}
+
 
 	// get status flags for a set of files...
 	FileStatusFlags fileInfo(const IntegritySession& session, const std::wstring& file) 


### PR DESCRIPTION
#138

The merge Conflicts menu item when selected, used ask to merge all the member files of the selected sandboxes no matter what the file status was. Now it just performs the action the selected file members of the sandbox. This action now just goes directly into the current working directory (cwd), no need to select the sandbox.
