### PR TITLE
Remove from the Exclude Filter Action

### DIFF
--- a/src/Resources/TortoiseShellENG.rc
+++ b/src/Resources/TortoiseShellENG.rc
@@ -199,7 +199,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_ETC                 "..."
-    IDS_SHOWING_PARTIAL_RESULTS "Remove the Exclude Filter "
+    IDS_SHOWING_PARTIAL_RESULTS "(Showing %1!d! of %2!d! only)"
 END
 
 STRINGTABLE

--- a/src/Resources/TortoiseShellENG.rc
+++ b/src/Resources/TortoiseShellENG.rc
@@ -199,7 +199,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_ETC                 "..."
-    IDS_SHOWING_PARTIAL_RESULTS "(Showing %1!d! of %2!d! only)"
+    IDS_SHOWING_PARTIAL_RESULTS "Remove the Exclude Filter "
 END
 
 STRINGTABLE
@@ -271,6 +271,8 @@ BEGIN
     IDS_VIEW_MYREVIEWS_DESC "Views all the Change PAckages Reviews of that User"
     IDS_MERGE_CONFLICTS     "Merge Conflicts"
     IDS_MERGE_CONFLICTS_DESC "Menu to Resolve Merge Conflicts"
+    IDS_REMOVE_SUBMENU      "Remove from Exclude Filter"
+    IDS_REMOVE_SUBMENU_DESC "Removes selected pattern from Non-Members View Exclude Filter"
 END
 
 #endif    // English (United States) resources

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -154,7 +154,6 @@ std::wstring getTopLevelSandbox(std::wstring path, HWND parentWindow) {
 */
 void updateExcludeFileFilter(const std::vector<std::wstring>& selectedItems, const std::wstring newExclude) {
 	// assume newExclude of the form "filename.extension" or "*.extension" 
-
 	if (selectedItems.empty()) {
 		EventLog::writeDebug(L"selected items list empty for ignore operations");
 		return;
@@ -168,13 +167,18 @@ void updateExcludeFileFilter(const std::vector<std::wstring>& selectedItems, con
 	// retrieve current exclude contents
 	std::vector<std::wstring> excludeContents = IntegrityActions::getExcludeFilterContents(getIntegritySession());
 
-	// append it to this list, error check for duplicates
+	// append it to this list
 	std::wstring newExcludeOption = L"file:" + newExclude;
-	if (std::find(excludeContents.begin(), excludeContents.end(), newExcludeOption) != excludeContents.end()) {
-		EventLog::writeDebug(L"Already contains pattern " + newExcludeOption);
-		return;
+
+	//Remove elements from the exclude Filter	
+	std::vector<std::wstring>::iterator it;
+	it = std::find(excludeContents.begin(), excludeContents.end(), newExcludeOption);
+	if (it != excludeContents.end()) {
+		excludeContents.erase(it);
 	}
-	excludeContents.push_back(newExcludeOption);
+	//Adding elements into the Exclude Filter
+	else
+		excludeContents.push_back(newExcludeOption);
 
 	// set prefs and refresh folder
 	IntegrityActions::setExcludeFileFilter(getIntegritySession(), excludeContents, [folder] { refreshFolder(folder); });
@@ -702,6 +706,16 @@ std::vector<MenuInfo> menuInfo =
 			return selectedItems.size() == 1 &&
 				hasFileStatus(selectedItemsStatus, FileStatus::File) && 
 				!hasFileStatus(selectedItemsStatus, FileStatus::Ignored);
+		}
+	},
+
+	{ MenuItem::UnIgnoreSubMenu, 0, IDS_REMOVE_SUBMENU, IDS_REMOVE_SUBMENU_DESC,
+	nullptr, // CShellExt::InsertIgnoreSubmenus define the actions associated with menu
+	[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
+		{
+			return selectedItems.size() == 1 &&
+				hasFileStatus(selectedItemsStatus, FileStatus::File) &&
+				hasFileStatus(selectedItemsStatus, FileStatus::Ignored);
 		}
 	},
 };

--- a/src/TortoiseShell/resource.h
+++ b/src/TortoiseShell/resource.h
@@ -155,7 +155,9 @@
 #define IDS_MENULOGSUBMODULE            211
 #define IDS_MERGE_CONFLICTS_DESC        211
 #define IDS_MENUUNDOADD                 212
+#define IDS_REMOVE_SUBMENU              212
 #define IDS_MENUDESCUNDOADD             213
+#define IDS_REMOVE_SUBMENU_DESC         213
 #define IDS_MENUPREVDIFF                214
 #define IDS_MENUDESCPREVDIFF            215
 #define IDS_MENUDAEMON                  216


### PR DESCRIPTION
#135 An action has been added which can directly remove elements selected from the Exclude file filter of the non-members of the sandbox
