### PR TITLE
limited file icon overlay for locked member updated to modified icon

### DIFF
--- a/src/TortoiseShell/IconOverlay.cpp
+++ b/src/TortoiseShell/IconOverlay.cpp
@@ -210,7 +210,9 @@ FileStatusFlags	CShellExt::getPathStatus(std::wstring path)
 		 if (g_lockedovlloaded && m_State == FileStateLockedOverlay) {
 			 return S_OK;
 		 }
-		 else if (!g_lockedovlloaded && m_State == FileStateVersioned) {
+		 else if (!g_lockedovlloaded && m_State == FileStateModified) {
+			 // the 'locked' overlay isn't available (due to lack of enough
+			 // overlay slots). So just show the 'modified' overlay instead.
 			 return S_OK;
 		 }
 		 else {


### PR DESCRIPTION
Fix #142

Lock icon dropped by TortoiseOverlay when number of registered icon overlays exceeds 12. Updated "limited file icon overlay" to display "modified" icon instead of "versioned" icon (checkmark). Icon should be now be visibly updated if file is locked.
