### PR TITLE
Added a Shortcut to "View related Change Packages"

### DIFF
--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -76,7 +76,7 @@ namespace IntegrityActions {
 		if (!developmentPath.empty())
 		{
 			IntegrityCommand command(L"si", L"viewcps");
-			command.addOption(L"filter", projectFilter);
+			command.addOption(L"filter", variantFilter);
 			command.addOption(L"g");
 			command.addOption(L"fields", L"id,summary,description,cptype,creationdate,issue");
 

--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -63,14 +63,8 @@ namespace IntegrityActions {
 		}
 
 		// Extract properties to be displayed from properties object
-		time_t lastCheckpoint = folderProp->getLastCheckpoint();
-
 		std::wstring developmentPath = folderProp->getDevelopmentPath();
 		std::wstring projectName = folderProp->getProjectName();
-		std::wstring sandboxName = folderProp->getSandboxName();
-		std::wstring serverName = folderProp->getServerName();
-		std::wstring serverPort = folderProp->getServerPort();
-		std::wstring revision = folderProp->getRevision();
 
 		std::wstring variantFilter = L"variant:" + developmentPath;
 		std::wstring projectFilter = L"project:" + projectName;
@@ -79,7 +73,7 @@ namespace IntegrityActions {
 		if (!developmentPath.empty())
 		{
 			IntegrityCommand command(L"si", L"viewcps");
-			command.addOption(L"filter", L"variantFilter, projectFilter");
+			command.addOption(L"filter", projectFilter);
 			command.addOption(L"g");
 			command.addOption(L"fields", L"id,summary,description,cptype,creationdate,issue");
 

--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -51,6 +51,54 @@ namespace IntegrityActions {
 		executeUserCommand(session, command, nullptr);
 	}
 
+	void viewRelatedChangePackages(const IntegritySession& session, std::wstring path)
+	{
+		/*const std::wstring folder;*/
+		std::shared_ptr<IntegrityActions::FolderProperties> folderProp =
+			IntegrityActions::getFolderInfo(session, path);
+
+		// Can't retrieve properties
+		if (!folderProp) {
+			return;
+		}
+
+		// Extract properties to be displayed from properties object
+		time_t lastCheckpoint = folderProp->getLastCheckpoint();
+
+		std::wstring developmentPath = folderProp->getDevelopmentPath();
+		std::wstring projectName = folderProp->getProjectName();
+		std::wstring sandboxName = folderProp->getSandboxName();
+		std::wstring serverName = folderProp->getServerName();
+		std::wstring serverPort = folderProp->getServerPort();
+		std::wstring revision = folderProp->getRevision();
+
+		std::wstring variantFilter = L"variant:" + developmentPath;
+		std::wstring projectFilter = L"project:" + projectName;
+
+		//Filter for Variant 
+		if (!developmentPath.empty())
+		{
+			IntegrityCommand command(L"si", L"viewcps");
+			command.addOption(L"filter", L"variantFilter, projectFilter");
+			command.addOption(L"g");
+			command.addOption(L"fields", L"id,summary,description,cptype,creationdate,issue");
+
+			executeUserCommand(session, command, nullptr);
+		}
+
+		//Filter for Mainline (Project)
+		else
+		{
+			IntegrityCommand command(L"si", L"viewcps");
+			command.addOption(L"filter", projectFilter);
+			command.addOption(L"g");
+			command.addOption(L"fields", L"id,summary,description,cptype,creationdate,issue");
+
+			executeUserCommand(session, command, nullptr);
+		}
+
+	}
+
 	void viewMyLocks(const IntegritySession& session, std::wstring path)
 	{
 		IntegrityCommand command(L"si", L"locks");

--- a/src/Integrity/IntegrityActions.h
+++ b/src/Integrity/IntegrityActions.h
@@ -275,6 +275,7 @@ namespace IntegrityActions {
 	void viewMyLocks(const IntegritySession& session, std::wstring path);
 	void viewMyProjectHistory(const IntegritySession& session, std::wstring path);
 	void viewMyProjectDifferences(const IntegritySession& session, std::wstring path);
+	void viewRelatedChangePackages(const IntegritySession& session, std::wstring path);
 
 	void lockFiles(const IntegritySession& session, std::vector<std::wstring> paths, std::function<void()> onDone);
 	void unlockFiles(const IntegritySession& session, std::vector<std::wstring> paths, std::function<void()> onDone);

--- a/src/Resources/TortoiseShellENG.rc
+++ b/src/Resources/TortoiseShellENG.rc
@@ -285,6 +285,8 @@ BEGIN
     IDS_VIEW_PROJECTDIFFERENCES_DESC 
                             "Shows Changes Made Since Last Checkpoint"
     IDS_VIEW_PROJECTDIFFERENCES "View Project Differences"
+    IDS_VIEW_RELATEDCP      "View Related Change Packages"
+    IDS_VIEW_RELATEDCP_DESC "Shows all Change Packages related to the Project represented by the selected Sandbox/Subsandbox."
 END
 
 #endif    // English (United States) resources

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -185,6 +185,7 @@ void updateExcludeFileFilter(const std::vector<std::wstring>& selectedItems, con
 
 std::vector<MenuInfo> menuInfo =
 {
+	menuSeperator,
 	{ MenuItem::ViewSandbox, IDI_REPOBROWSE, IDS_VIEW_SANDBOX, IDS_VIEW_SANDBOX_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND)
 	{
@@ -215,6 +216,48 @@ std::vector<MenuInfo> menuInfo =
 			!hasFileStatus(selectedItemsStatus, FileStatus::Member);
 	}
 	},
+
+	{ MenuItem::ViewRelatedChangePackages, IDI_REPOBROWSE, IDS_VIEW_RELATEDCP, IDS_VIEW_RELATEDCP_DESC,
+	[](const std::vector<std::wstring>& selectedItems, HWND)
+	{
+		IntegrityActions::viewRelatedChangePackages(getIntegritySession(), selectedItems.front());
+	},
+		[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
+	{
+		return selectedItems.size() == 1 &&
+			hasFileStatus(selectedItemsStatus, FileStatus::Folder) &&
+			hasFileStatus(selectedItemsStatus, FileStatus::Member);
+	}
+	},
+
+	{ MenuItem::ViewMyProjectHistory, IDI_REVISIONGRAPH, IDS_VIEW_PROJECTHISTORY, IDS_VIEW_PROJECTHISTORY_DESC,
+	[](const std::vector<std::wstring>& selectedItems, HWND)
+	{
+		IntegrityActions::viewMyProjectHistory(getIntegritySession(), selectedItems.front());
+	},
+		[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
+	{
+		return selectedItems.size() == 1 &&
+			hasFileStatus(selectedItemsStatus, FileStatus::Folder) &&
+			hasFileStatus(selectedItemsStatus, FileStatus::Member);
+	}
+	},
+
+
+	{ MenuItem::ViewMyProjectDifferences, IDI_REPOBROWSE, IDS_VIEW_PROJECTDIFFERENCES, IDS_VIEW_PROJECTDIFFERENCES_DESC,
+	[](const std::vector<std::wstring>& selectedItems, HWND)
+	{
+		IntegrityActions::viewMyProjectDifferences(getIntegritySession(), selectedItems.front());
+	},
+		[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
+	{
+		return selectedItems.size() == 1 &&
+			hasFileStatus(selectedItemsStatus, FileStatus::Folder) &&
+			hasFileStatus(selectedItemsStatus, FileStatus::Member);
+	}
+	},
+
+	menuSeperator,
 	{ MenuItem::ViewMyChangePackages, IDI_REPOBROWSE, IDS_VIEW_CHANGEPACKAGES, IDS_VIEW_CHANGEPACKAGES_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND)
 	{
@@ -224,35 +267,12 @@ std::vector<MenuInfo> menuInfo =
 	{
 		return true;
 	}
-	},
+	},	
 
-	{ MenuItem::viewMyLocks, IDI_REPOBROWSE, IDS_VIEW_LOCKS, IDS_VIEW_LOCKS_DESC,
+	{ MenuItem::viewMyLocks, IDI_LOCK, IDS_VIEW_LOCKS, IDS_VIEW_LOCKS_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND)
 	{
 		IntegrityActions::viewMyLocks(getIntegritySession(), selectedItems.front());
-	},
-		[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
-	{
-		return true;
-	}
-	},
-
-	{ MenuItem::ViewMyProjectHistory, IDI_REPOBROWSE, IDS_VIEW_PROJECTHISTORY, IDS_VIEW_PROJECTHISTORY_DESC,
-	[](const std::vector<std::wstring>& selectedItems, HWND)
-	{
-		IntegrityActions::viewMyProjectHistory(getIntegritySession(), selectedItems.front());
-	},
-		[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
-	{
-		return true;
-	}
-	},
-
-
-	{ MenuItem::ViewMyProjectDifferences, IDI_REPOBROWSE, IDS_VIEW_PROJECTDIFFERENCES, IDS_VIEW_PROJECTDIFFERENCES_DESC,
-	[](const std::vector<std::wstring>& selectedItems, HWND)
-	{
-		IntegrityActions::viewMyProjectDifferences(getIntegritySession(), selectedItems.front());
 	},
 		[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
 	{

--- a/src/TortoiseShell/MenuInfo.h
+++ b/src/TortoiseShell/MenuInfo.h
@@ -22,14 +22,17 @@
 #include "FileStatus.h"
 
 enum MenuItem {
-	WorkingFileChangesView,
-	ViewSandbox,
 	CreateSandbox,
-	ViewMyChangePackages,
-	ViewMyReviews,
-	viewMyLocks,
+	ViewSandbox,
 	ViewMyProjectHistory,
 	ViewMyProjectDifferences,
+	ViewRelatedChangePackages,
+
+	ViewMyChangePackages,
+	WorkingFileChangesView,
+	viewMyLocks,
+	ViewMyReviews,
+
 	MergeConflicts,
 
 	IgnoreSubMenu,

--- a/src/TortoiseShell/resource.h
+++ b/src/TortoiseShell/resource.h
@@ -77,6 +77,8 @@
 #define IDS_VIEW_PROJECTHISTORY_DESC    217
 #define IDS_VIEW_PROJECTDIFFERENCES_DESC 218
 #define IDS_VIEW_PROJECTDIFFERENCES     219
+#define IDS_VIEW_RELATEDCP              220
+#define IDS_VIEW_RELATEDCP_DESC         221
 #define IDI_MENUSYNC                    321
 #define IDI_REVISIONGRAPH               366
 #define IDS_LOADING                     369
@@ -148,7 +150,6 @@
 #define IDI_DAEMON                      5180
 #define IDI_MERGEABORT                  5181
 #define IDI_LOCK                        5183
-#define IDI_ICON2                       5187
 #define IDC_CONFIG_AUTOCRLF             11020
 #define IDC_SHELL_REMOTE_BRANCH         11022
 #define IDC_ESCAPEDURLLABEL             11023


### PR DESCRIPTION
#153 added shortcut for " View Related Change Packages" and added a filter for mainline and variant.

Also made some changes in the orientation of the menu items and their icons.
