### PR TITLE
integrity command for my reviews got changed unknowingly

### DIFF
--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -122,7 +122,7 @@ namespace IntegrityActions {
 
 	void viewMyReviews(const IntegritySession& session, std::wstring path)
 	{
-		IntegrityCommand command(L"si", L"locks");
+		IntegrityCommand command(L"si", L"viewcps");
 		command.addOption(L"g");
 		command.addOption(L"myReviews");
 

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -269,7 +269,7 @@ std::vector<MenuInfo> menuInfo =
 	}
 	},	
 
-	{ MenuItem::viewMyLocks, IDI_LOCK, IDS_VIEW_LOCKS, IDS_VIEW_LOCKS_DESC,
+	{ MenuItem::ViewMyLocks, IDI_LOCK, IDS_VIEW_LOCKS, IDS_VIEW_LOCKS_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND)
 	{
 		IntegrityActions::viewMyLocks(getIntegritySession(), selectedItems.front());

--- a/src/TortoiseShell/MenuInfo.h
+++ b/src/TortoiseShell/MenuInfo.h
@@ -30,7 +30,7 @@ enum MenuItem {
 
 	ViewMyChangePackages,
 	WorkingFileChangesView,
-	viewMyLocks,
+	ViewMyLocks,
 	ViewMyReviews,
 
 	MergeConflicts,


### PR DESCRIPTION
#137   integrity command for my reviews got changed unknowingly which made it do nothing. Changed it back to its original command. its working and ready to be tested.
