### PR TITLE
Made changes to "View Project History" and "View Project Differences"

### DIFF
--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -96,17 +96,10 @@ namespace IntegrityActions {
 
 	}
 
-	void viewMyLocks(const IntegritySession& session, std::wstring path)
-	{
-		IntegrityCommand command(L"si", L"locks");
-		command.addOption(L"g");
-
-		executeUserCommand(session, command, nullptr);
-	}
-
 	void viewMyProjectHistory(const IntegritySession& session, std::wstring path)
 	{
 		IntegrityCommand command(L"si", L"viewprojecthistory");
+		command.addOption(L"cwd", path);
 		command.addOption(L"g");
 
 		executeUserCommand(session, command, nullptr);
@@ -115,6 +108,7 @@ namespace IntegrityActions {
 	void viewMyProjectDifferences(const IntegritySession& session, std::wstring path)
 	{
 		IntegrityCommand command(L"si", L"mods");
+		command.addOption(L"cwd", path);
 		command.addOption(L"g");
 
 		executeUserCommand(session, command, nullptr);


### PR DESCRIPTION
#161 #162 Made changes to "View Project History" and "View Project Differences" menu actions which results in showing the items from the working directory/sandbox.

Removed the "View My Locks" #159 option to make some changes.
