### PR TITLE
Made changes to "View Project History" and "View Project Differences"

### DIFF
--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -96,17 +96,10 @@ namespace IntegrityActions {
 
 	}
 
-	void viewMyLocks(const IntegritySession& session, std::wstring path)
-	{
-		IntegrityCommand command(L"si", L"locks");
-		command.addOption(L"g");
-
-		executeUserCommand(session, command, nullptr);
-	}
-
 	void viewMyProjectHistory(const IntegritySession& session, std::wstring path)
 	{
 		IntegrityCommand command(L"si", L"viewprojecthistory");
+		command.addOption(L"cwd", path);
 		command.addOption(L"g");
 
 		executeUserCommand(session, command, nullptr);
@@ -115,6 +108,7 @@ namespace IntegrityActions {
 	void viewMyProjectDifferences(const IntegritySession& session, std::wstring path)
 	{
 		IntegrityCommand command(L"si", L"mods");
+		command.addOption(L"cwd", path);
 		command.addOption(L"g");
 
 		executeUserCommand(session, command, nullptr);

--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -98,16 +98,6 @@ namespace IntegrityActions {
 
 	void viewMyProjectHistory(const IntegritySession& session, std::wstring path)
 	{
-		std::shared_ptr<IntegrityActions::FolderProperties> folderProp =
-			IntegrityActions::getFolderInfo(session, path);
-
-		// Can't retrieve properties
-		if (!folderProp) {
-			return;
-		}
-
-		// Extract properties to be displayed from properties object
-		std::wstring sandboxName = folderProp->getSandboxName();
 		IntegrityCommand command(L"si", L"viewprojecthistory");
 		command.addOption(L"cwd", path);
 		command.addOption(L"g");
@@ -117,17 +107,8 @@ namespace IntegrityActions {
 
 	void viewMyProjectDifferences(const IntegritySession& session, std::wstring path)
 	{
-
-		std::shared_ptr<IntegrityActions::FolderProperties> folderProp =
-			IntegrityActions::getFolderInfo(session, path);
-
-		// Can't retrieve properties
-		if (!folderProp) {
-			return;
-		}
-
-		// Extract properties to be displayed from properties object
-		std::wstring sandboxName = folderProp->getSandboxName();
+		// Get the SandBox Name
+		std::wstring sandboxName = getSandboxName(session, path);
 
 		IntegrityCommand command(L"si", L"mods");
 		command.addOption(L"sandbox", sandboxName);

--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -98,6 +98,16 @@ namespace IntegrityActions {
 
 	void viewMyProjectHistory(const IntegritySession& session, std::wstring path)
 	{
+		std::shared_ptr<IntegrityActions::FolderProperties> folderProp =
+			IntegrityActions::getFolderInfo(session, path);
+
+		// Can't retrieve properties
+		if (!folderProp) {
+			return;
+		}
+
+		// Extract properties to be displayed from properties object
+		std::wstring sandboxName = folderProp->getSandboxName();
 		IntegrityCommand command(L"si", L"viewprojecthistory");
 		command.addOption(L"cwd", path);
 		command.addOption(L"g");
@@ -107,8 +117,20 @@ namespace IntegrityActions {
 
 	void viewMyProjectDifferences(const IntegritySession& session, std::wstring path)
 	{
+
+		std::shared_ptr<IntegrityActions::FolderProperties> folderProp =
+			IntegrityActions::getFolderInfo(session, path);
+
+		// Can't retrieve properties
+		if (!folderProp) {
+			return;
+		}
+
+		// Extract properties to be displayed from properties object
+		std::wstring sandboxName = folderProp->getSandboxName();
+
 		IntegrityCommand command(L"si", L"mods");
-		command.addOption(L"cwd", path);
+		command.addOption(L"sandbox", sandboxName);
 		command.addOption(L"g");
 
 		executeUserCommand(session, command, nullptr);

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -269,7 +269,7 @@ std::vector<MenuInfo> menuInfo =
 	}
 	},	
 
-	{ MenuItem::ViewMyLocks, IDI_LOCK, IDS_VIEW_LOCKS, IDS_VIEW_LOCKS_DESC,
+	/*{ MenuItem::ViewMyLocks, IDI_LOCK, IDS_VIEW_LOCKS, IDS_VIEW_LOCKS_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND)
 	{
 		IntegrityActions::viewMyLocks(getIntegritySession(), selectedItems.front());
@@ -278,7 +278,7 @@ std::vector<MenuInfo> menuInfo =
 	{
 		return true;
 	}
-	},
+	},*/
 
 	{ MenuItem::ViewMyReviews, IDI_REPOBROWSE, IDS_VIEW_MYREVIEWS, IDS_VIEW_MYREVIEWS_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND)

--- a/src/TortoiseShell/MenuInfo.h
+++ b/src/TortoiseShell/MenuInfo.h
@@ -30,7 +30,7 @@ enum MenuItem {
 
 	ViewMyChangePackages,
 	WorkingFileChangesView,
-	ViewMyLocks,
+	/*ViewMyLocks,*/
 	ViewMyReviews,
 
 	MergeConflicts,


### PR DESCRIPTION
#161 #162  Made changes to "View Project History" and "View Project Differences" menu actions which results in showing the items from the working directory/sandbox.

Removed the "View My Locks" #159 option to make some changes.
