### PR TITLE
Added a Functionality to drop a Sub Project when a folder is selected

### DIFF
--- a/src/Integrity/IntegrityActions.h
+++ b/src/Integrity/IntegrityActions.h
@@ -203,6 +203,7 @@ namespace IntegrityActions {
 			std::wstring m_serverName;
 			std::wstring m_serverPort;
 			std::wstring m_revision;
+			std::wstring m_modelType;
 
 		public:
 			FolderProperties() {};
@@ -214,11 +215,13 @@ namespace IntegrityActions {
 			std::wstring getServerName() { return m_serverName; }
 			std::wstring getServerPort() { return m_serverPort; }
 			std::wstring getRevision() { return m_revision; }
+			std::wstring getModelType() { return m_modelType; }
 
 			void setLastCheckpoint(time_t lastCheckpoint) { m_lastCheckpoint = lastCheckpoint; }
 			void setDevelopmentPath(std::wstring developmentPath) { m_developmentPath = developmentPath; }
 			void setSandboxName(std::wstring sandboxName) { m_sandboxName = sandboxName; }
 			void setProjectName(std::wstring projectName) { m_projectName = projectName; }
+			void setModelType(std::wstring projectName) { m_projectName = m_modelType; }
 			void setServerName(std::wstring serverName) { m_serverName = serverName; }
 			void setServerPort(std::wstring serverPort) { m_serverPort = serverPort; }
 			void setRevision(std::wstring revision) { m_revision = revision; }
@@ -257,6 +260,9 @@ namespace IntegrityActions {
 	// list of working file changes
 	std::vector<std::shared_ptr<IntegrityActions::WorkingFileChange>> getWorkingFileChanges(const IntegritySession& session, std::wstring path);
 
+	//Get Model Type
+	std::wstring getmodelType(const IntegritySession& session, std::wstring path);
+
 	bool connect(const IntegritySession& session);
 
 	void launchSandboxView(const IntegritySession& session, std::wstring path);
@@ -292,6 +298,7 @@ namespace IntegrityActions {
 
 	void createSandbox(const IntegritySession& session, std::wstring path, std::function<void()> onDone);
 	void dropSandbox(const IntegritySession& session, std::wstring path, std::function<void()> onDone);
+	void dropProject(const IntegritySession& session, std::wstring path, std::function<void()> onDone);
 	void resyncFiles(const IntegritySession& session, std::vector<std::wstring> paths, std::function<void()> onDone);
 	void resyncEntireSandbox(const IntegritySession& session, std::wstring path, std::function<void()> onDone);
 	void retargetSandbox(const IntegritySession& session, std::wstring path, std::function<void()> onDone);

--- a/src/Resources/TortoiseShellENG.rc
+++ b/src/Resources/TortoiseShellENG.rc
@@ -287,6 +287,8 @@ BEGIN
     IDS_VIEW_PROJECTDIFFERENCES "View Project Differences"
     IDS_VIEW_RELATEDCP      "View Related Change Packages"
     IDS_VIEW_RELATEDCP_DESC "Shows all Change Packages related to the Project represented by the selected Sandbox/Subsandbox."
+    IDS_DROP_SUBPROJECT     "Drop Sub-Project"
+    IDS_DROP_SUBPROJECT_DESC "Drops the whole Sub-Project"
 END
 
 #endif    // English (United States) resources

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -401,6 +401,35 @@ std::vector<MenuInfo> menuInfo =
 				hasFileStatus(selectedItemsStatus, FileStatus::Member);
 		}
 	},
+
+	{ MenuItem::DropSubProject, IDI_DELETE, IDS_DROP_SUBPROJECT, IDS_DROP_SUBPROJECT_DESC,
+	[](const std::vector<std::wstring>& selectedItems, HWND)
+		{
+			std::wstring folder;
+			std::wstring file;
+
+			if (selectedItems.empty()) {
+				EventLog::writeDebug(L"selected items list empty for drop sandbox operation");
+				return;
+			}
+
+			// First selected file
+			file = selectedItems.front();
+			// Extract folder name from file path
+			folder = file.substr(0, file.find_last_of('\\'));
+
+			IntegrityActions::dropProject(getIntegritySession(), selectedItems.front(),
+				[folder]{ refreshFolder(folder); });
+		},
+			[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
+		{
+			std::wstring modelType;
+			modelType = IntegrityActions::getmodelType(getIntegritySession(), selectedItems.front());
+			return selectedItems.size() == 1 &&
+				(modelType==L"si.Subproject");
+		}
+	},
+
 	{ MenuItem::RetargetSandbox, IDI_RELOCATE, IDS_RETARGET_SANDBOX, IDS_RETARGET_SANDBOX_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND parentWindow)
 		{
@@ -657,6 +686,36 @@ std::vector<MenuInfo> menuInfo =
 				hasFileStatus(selectedItemsStatus, FileStatus::Member);
 		}
 	},
+
+	/*{ MenuItem::DropSubProject, IDI_DELETE, IDS_DROP_SUBPROJECT, IDS_DROP_SUBPROJECT_DESC,
+	[](const std::vector<std::wstring>& selectedItems, HWND parentWindow)
+		{
+			std::wstring file;
+			std::wstring folder;
+			std::wstring projectName;
+
+			file = selectedItems.front();
+
+			folder = file.substr(0, file.find_last_of('\\'));
+
+			std::shared_ptr<IntegrityActions::FolderProperties> folderProp =
+				IntegrityActions::getFolderInfo(getIntegritySession(), folder);
+
+			if (!folderProp) {
+				return;
+			}
+
+			projectName = folderProp->getProjectName();
+
+			IntegrityActions::dropSubproject(getIntegritySession(), projectName, selectedItems,
+				[folder] {refreshFolder(folder); });
+		},
+			[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
+		{
+			return true;
+		}
+	},*/
+
 	{ MenuItem::Lock, IDI_LOCK, IDS_LOCK, IDS_LOCK_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND parentWindow)
 		{

--- a/src/TortoiseShell/MenuInfo.h
+++ b/src/TortoiseShell/MenuInfo.h
@@ -52,6 +52,7 @@ enum MenuItem {
 	Add,
 	CheckOut,
 	Drop,
+	DropSubProject,
 	Lock,
 	CheckIn,
 	Revert,

--- a/src/TortoiseShell/resource.h
+++ b/src/TortoiseShell/resource.h
@@ -79,6 +79,8 @@
 #define IDS_VIEW_PROJECTDIFFERENCES     219
 #define IDS_VIEW_RELATEDCP              220
 #define IDS_VIEW_RELATEDCP_DESC         221
+#define IDS_DROP_SUBPROJECT             222
+#define IDS_DROP_SUBPROJECT_DESC        223
 #define IDI_MENUSYNC                    321
 #define IDI_REVISIONGRAPH               366
 #define IDS_LOADING                     369


### PR DESCRIPTION
#158

The menu option "Drop Sub-Project" will only appear if the selected item is either in the subproject or a sub project. Otherwise this option will not show up. this is different from the "drop Sandbox" and "Drop" (to drop memebers) option.
