### PR TITLE
Fixed the drop sub project option

### DIFF
--- a/src/Integrity/IntegrityActions.h
+++ b/src/Integrity/IntegrityActions.h
@@ -248,6 +248,9 @@ namespace IntegrityActions {
 	// name of specific sandbox (includes .pj file)
 	std::wstring getSandboxName(const IntegritySession& session, std::wstring path);
 
+	//name of specific Project
+	std::wstring getProjectName(const IntegritySession& session, std::wstring path);
+
 	//Get Current Username
 	std::wstring getUserName(const IntegritySession& session);
 


### PR DESCRIPTION
#158

"si dropproject" only works to drop a project and not a sub project. to drop a sub project used "si drop -p <parent project name> <subproject name>
added a "get projectName" functionality to avoid calling the folder properties all the time.
