### PR TITLE
fixed the issue where an error appears when a nonmember or a folder outside the sandbox directory is clicked.

### DIFF
--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -470,6 +470,8 @@ std::vector<MenuInfo> menuInfo =
 			[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)
 		{
 			return selectedItems.size() == 1 &&
+				hasFileStatus(selectedItemsStatus, FileStatus::Folder) &&
+				hasFileStatus(selectedItemsStatus, FileStatus::Member)&&
 				IntegrityActions::isSubProject(getIntegritySession(), selectedItems.front());
 		}
 	},


### PR DESCRIPTION
#158 this error came while creating this feature. added the condition to show this menu option when if its a member and folder.
