### PR TITLE
Fixed an issue where the Resynchronize Menu Option won't do anything

### DIFF
--- a/src/Integrity/IntegrityActions.cpp
+++ b/src/Integrity/IntegrityActions.cpp
@@ -304,7 +304,7 @@ namespace IntegrityActions {
 	{
 		IntegrityCommand command(L"si", L"resync");
 		command.addOption(L"g");
-		command.addOption(L"sandbox", path);
+		command.addOption(L"cwd", path);
 
 		executeUserCommand(session, command, onDone);
 	}

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -160,14 +160,6 @@ std::wstring getTopLevelSandbox(std::wstring path, HWND parentWindow) {
 }
 
 /**
-* Find a registered sandbox regardless of whether it is a top
-* level sandbox
-*/
-std::wstring getRegisteredSandbox(std::wstring path, HWND parentWindow) {
-	return getSandbox(path, parentWindow, false);
-}
-
-/**
 * Get current contents of the exclude filter, add new pattern (if it is not already in the filter), and update the exclude filter
 */
 void updateExcludeFileFilter(const std::vector<std::wstring>& selectedItems, const std::wstring newExclude) {
@@ -351,21 +343,6 @@ std::vector<MenuInfo> menuInfo =
 			file = selectedItems.front();
 
 			folder = file.substr(0, file.find_last_of('\\'));
-			/*std::wstring sandboxName;
-			std::wstring folder;
-
-			if (selectedItems.empty()) {
-				EventLog::writeDebug(L"selected items list empty for resync operation");
-				return;
-			}
-
-			// Error will be displayed if multiple sandboxes found
-			sandboxName = IntegrityActions::getSandboxName(getIntegritySession(), selectedItems.front());
-			if (sandboxName.empty())
-				return;
-
-			// Extract folder name from file path
-			folder = sandboxName.substr(0, sandboxName.find_last_of('\\'));*/
 
 			IntegrityActions::resyncSandbox(getIntegritySession(), file,
 				[folder]{ refreshFolder(folder); });
@@ -380,7 +357,6 @@ std::vector<MenuInfo> menuInfo =
 	{ MenuItem::Resync, IDI_PULL, IDS_RESYNC, IDS_RESYNC_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND parentWindow)
 		{
-			std::wstring sandboxName;
 			std::wstring file;
 			std::wstring folder;
 

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -340,7 +340,18 @@ std::vector<MenuInfo> menuInfo =
 	{ MenuItem::Resync, IDI_PULL, IDS_RESYNC, IDS_RESYNC_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND parentWindow)
 		{
-			std::wstring sandboxName;
+			std::wstring file;
+			std::wstring folder;
+
+			if (selectedItems.empty()) {
+				EventLog::writeDebug(L"selected items list empty for rename operation");
+				return;
+			}
+
+			file = selectedItems.front();
+
+			folder = file.substr(0, file.find_last_of('\\'));
+			/*std::wstring sandboxName;
 			std::wstring folder;
 
 			if (selectedItems.empty()) {
@@ -349,14 +360,14 @@ std::vector<MenuInfo> menuInfo =
 			}
 
 			// Error will be displayed if multiple sandboxes found
-			sandboxName = getRegisteredSandbox(selectedItems.front(), parentWindow);
+			sandboxName = IntegrityActions::getSandboxName(getIntegritySession(), selectedItems.front());
 			if (sandboxName.empty())
 				return;
 
 			// Extract folder name from file path
-			folder = sandboxName.substr(0, sandboxName.find_last_of('\\'));
+			folder = sandboxName.substr(0, sandboxName.find_last_of('\\'));*/
 
-			IntegrityActions::resyncSandbox(getIntegritySession(), sandboxName,
+			IntegrityActions::resyncSandbox(getIntegritySession(), file,
 				[folder]{ refreshFolder(folder); });
 		},
 			[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -336,7 +336,7 @@ std::vector<MenuInfo> menuInfo =
 			std::wstring folder;
 
 			if (selectedItems.empty()) {
-				EventLog::writeDebug(L"selected items list empty for rename operation");
+				EventLog::writeDebug(L"selected items list empty for resync operation");
 				return;
 			}
 

--- a/src/TortoiseShell/MenuInfo.cpp
+++ b/src/TortoiseShell/MenuInfo.cpp
@@ -332,7 +332,7 @@ std::vector<MenuInfo> menuInfo =
 	{ MenuItem::Resync, IDI_PULL, IDS_RESYNC, IDS_RESYNC_DESC,
 	[](const std::vector<std::wstring>& selectedItems, HWND parentWindow)
 		{
-			std::wstring file;
+			std::wstring selectedFolder;
 			std::wstring folder;
 
 			if (selectedItems.empty()) {
@@ -340,11 +340,11 @@ std::vector<MenuInfo> menuInfo =
 				return;
 			}
 
-			file = selectedItems.front();
+			selectedFolder = selectedItems.front();
 
-			folder = file.substr(0, file.find_last_of('\\'));
+			folder = selectedFolder.substr(0, selectedFolder.find_last_of('\\'));
 
-			IntegrityActions::resyncSandbox(getIntegritySession(), file,
+			IntegrityActions::resyncSandbox(getIntegritySession(), selectedFolder,
 				[folder]{ refreshFolder(folder); });
 		},
 			[](const std::vector<std::wstring>& selectedItems, FileStatusFlags selectedItemsStatus)


### PR DESCRIPTION
#185 replaced "si resync --sandbox" by "si resync --cwd"

the --sandbox would work too. but the SandboxName was returned as empty for the si resync and because of that this was happening.
